### PR TITLE
fix: date comparison

### DIFF
--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -152,7 +152,7 @@ func (p *LightningPoller) updatePosition(key string, recordsJson []byte) error {
 	position := p.positions[key]
 	// if the date is the same, add the offsets. This would happen if you got several pages with the same date. If you
 	/// don't combine the offsets then you'll just get the same page of data over and over forever.
-	if position.LastModifiedDate == newPosition.LastModifiedDate {
+	if position.LastModifiedDate.Equal(*newPosition.LastModifiedDate) {
 		position.Offset += newPosition.Offset
 	} else {
 		// date is different, replace the position entirely


### PR DESCRIPTION
current if statement is comparing pointer addresses, resulting in the
offset always getting reset.

Use time.Time.Equal() instead of ==, because the time.Time documentation
recommends it.

> In general, prefer t.Equal(u) to t == u, since t.Equal uses the most
> accurate comparison available and correctly handles the case when only
> one of its arguments has a monotonic clock reading.
> https://pkg.go.dev/time#Time