### PR TITLE
fix: implement a starting position override configuration

### DIFF
--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -313,7 +313,7 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	viper.SetDefault("persistence_enabled", false)
 	viper.SetDefault("persistence_path", ".")
 	viper.SetDefault("api_version", "54.0")
-	viper.SetDefault("startup_position_override", "")
+	viper.SetDefault("startup_position_overrides", "")
 	startupPositionOverridesAsStrings := viper.GetStringMapString("startup_position_overrides")
 	logging.Log.WithFields(logrus.Fields{"startupPositionOverridesAsStrings": startupPositionOverridesAsStrings}).Debug("startup position overrides as strings")
 	startupPositionOverrides, err := stringMapToTimeMap(startupPositionOverridesAsStrings)

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -38,10 +38,10 @@ type LightningPoller struct {
 
 type RunConfig struct {
 	Queries                 []QueryWithCallback `validate:"required"`
+	StartupPositionOverride map[string]time.Time
 	Ticker                  *time.Ticker
-	PersistenceEnabled      bool                 `json:"persistence_enabled"`
-	PersistencePath         string               `json:"persistence_path"`
-	StartupPositionOverride map[string]time.Time `json:"startup_position_override"`
+	PersistenceEnabled      bool   `json:"persistence_enabled"`
+	PersistencePath         string `json:"persistence_path"`
 }
 
 type QueryWithCallback struct {
@@ -319,6 +319,7 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	if err != nil {
 		return nil, errorx.Decorate(err, "error initializing config, unable to parse startup_position_override")
 	}
+	logging.Log.WithFields(logrus.Fields{"startupPositionOverride": startupPositionOverride}).Debug("startup position override")
 	config := &RunConfig{
 		Queries:                 queries,
 		Ticker:                  time.NewTicker(viper.GetDuration("poll_interval")),

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -314,11 +314,7 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	viper.SetDefault("persistence_path", ".")
 	viper.SetDefault("api_version", "54.0")
 	viper.SetDefault("startup_position_overrides", "")
-	testStringMap := viper.GetString("startup_position_overrides")
-	logging.Log.WithFields(logrus.Fields{"startupPositionOverrides": testStringMap}).Debug("startup position overrides as one string")
-	startupPositionOverridesAsStrings := viper.GetStringMapString("startup_position_overrides")
-	logging.Log.WithFields(logrus.Fields{"startupPositionOverridesAsStrings": startupPositionOverridesAsStrings}).Debug("startup position overrides as strings")
-	startupPositionOverrides, err := stringMapToTimeMap(startupPositionOverridesAsStrings)
+	startupPositionOverrides, err := stringToTimeMap(viper.GetString("startup_position_overrides"))
 	if err != nil {
 		return nil, errorx.Decorate(err, "error initializing config, unable to parse startup_position_override")
 	}
@@ -342,10 +338,15 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	return config, nil
 }
 
-func stringMapToTimeMap(i map[string]string) (o map[string]time.Time, err error) {
+func stringToTimeMap(i string) (o map[string]time.Time, err error) {
 	o = map[string]time.Time{}
-	for k, v := range i {
-		o[k], err = time.Parse(time.RFC3339, v)
+	stringArray := strings.Split(i, ",")
+	for _, s := range stringArray {
+		kvp := strings.Split(s, "=")
+		if len(kvp) != 2 {
+			return nil, errorx.IllegalArgument.New("string map invalid format")
+		}
+		o[kvp[0]], err = time.Parse(time.RFC3339, kvp[1])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -314,6 +314,8 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	viper.SetDefault("persistence_path", ".")
 	viper.SetDefault("api_version", "54.0")
 	viper.SetDefault("startup_position_overrides", "")
+	testStringMap := viper.GetString("startup_position_overrides")
+	logging.Log.WithFields(logrus.Fields{"startupPositionOverrides": testStringMap}).Debug("startup position overrides as one string")
 	startupPositionOverridesAsStrings := viper.GetStringMapString("startup_position_overrides")
 	logging.Log.WithFields(logrus.Fields{"startupPositionOverridesAsStrings": startupPositionOverridesAsStrings}).Debug("startup position overrides as strings")
 	startupPositionOverrides, err := stringMapToTimeMap(startupPositionOverridesAsStrings)


### PR DESCRIPTION
This totally ignores persistence during start up and hardcodes a start time.

Usage is to specify a start time via the LP_STARTUP_POSITION_OVERRIDES environment variable in a `key=value` map, where the key is the persistence key for the desired object and the value is a date time string in RFC3339 format. After the poller has completed a single query, the persistent storage will have updated to a new time, the configuration can then be removed so that the poller uses its saved lastModifiedDate at startup again.

Use cases for this are:
- setting a start date for a new object that had records synced by other means
- sending the poller back in time for a particular object so that its records are re-synced