### PR TITLE
fix: stringToTimeMap func, return empty map if string is empty

### DIFF
--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -340,15 +340,17 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 
 func stringToTimeMap(i string) (o map[string]time.Time, err error) {
 	o = map[string]time.Time{}
-	stringArray := strings.Split(i, ",")
-	for _, s := range stringArray {
-		kvp := strings.Split(s, "=")
-		if len(kvp) != 2 {
-			return nil, errorx.IllegalArgument.New("string map invalid format")
-		}
-		o[kvp[0]], err = time.Parse(time.RFC3339, kvp[1])
-		if err != nil {
-			return nil, err
+	if i != "" {
+		stringArray := strings.Split(i, ",")
+		for _, s := range stringArray {
+			kvp := strings.Split(s, "=")
+			if len(kvp) != 2 {
+				return nil, errorx.IllegalArgument.New("string map invalid format")
+			}
+			o[kvp[0]], err = time.Parse(time.RFC3339, kvp[1])
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return o, nil


### PR DESCRIPTION
Ran into a problem locally after merging #13 where if the LP_STARTUP_POSITION_OVERRIDES was empty, the stringToTimeMap function was ending up inside of the for loop of the stringArray. Turns out if you split an empty string, you end up with an array with one empty string in it. In my testing I was printing my array, and golang's default array to string functionality doesn't clearly show you that the array has an empty element in it, it only shows `[]` which is quite confusing. Anyways, this mitigates that.