### PR TITLE
feat: refactor last queried records 

### DIFF
--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -254,6 +254,7 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 		correctedIterator := 0
 		for i := int64(0); i < length; i++ {
 			recordID := gjson.GetBytes(recordsJSON, fmt.Sprintf("%d.Id", i)).String()
+			logging.Log.WithFields(logrus.Fields{"record_id": recordID}).Debug("checking record ID")
 			// check if the record ID is in the map of previously queried IDs.
 			// this prevents requeried record from being sent to the callback
 			// function every time after the poller has caught up.
@@ -267,6 +268,7 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 					err = recordTimestampErr
 					return
 				}
+				logging.Log.WithFields(logrus.Fields{"record_id": recordID, "timestamp": currentRecordTimestamp}).Debug("checking record timestamp")
 				if recordsPreviousLastModifiedDate.Equal(currentRecordTimestamp) {
 					logging.Log.WithFields(logrus.Fields{"record_id": recordID, "timestamp": currentRecordTimestamp}).Debug("removing record from json")
 					newRecordsJSON, err = sjson.DeleteBytes(newRecordsJSON, fmt.Sprintf("%d", correctedIterator))

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -324,7 +324,7 @@ func getPositionFromResult(response pkg.SoqlResponse, recordsJSON []byte, previo
 	// append the new IDs to the previous IDs. this prevents an infinite loop
 	// that occurs if the response from salesforce changes as a result of
 	// eventual consistency
-	logging.Log.WithFields(logrus.Fields{"previous_last_modified_date": &previousPosition.LastModifiedDate, "new_position": timestamp}).Debug("comparing last modified dates")
+	logging.Log.WithFields(logrus.Fields{"previous_last_modified_date": *previousPosition.LastModifiedDate, "new_position": timestamp}).Debug("comparing last modified dates")
 	if previousPosition.LastModifiedDate != nil && previousPosition.LastModifiedDate.Equal(timestamp) {
 		logging.Log.WithFields(logrus.Fields{"previous_record_ids": previousPosition.PreviousRecordIDs}).Debug("last modified date is the same as previous poll, appending IDs")
 		lastQueriedIDs = previousPosition.PreviousRecordIDs

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -340,6 +340,7 @@ func getPositionFromResult(response pkg.SoqlResponse, recordsJSON []byte, previo
 		}
 		lastQueriedIDs[id] = &recordTimestamp
 	}
+	logging.Log.WithFields(logrus.Fields{"last_queried_ids": lastQueriedIDs}).Debug("updated last queried IDs")
 	position.PreviousRecordIDs = lastQueriedIDs
 	position.NextURL = response.NextRecordsUrl
 	return

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -249,6 +249,7 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 	if resultLastModifiedDate.Equal(*positionLastModifiedDate) {
 		// last modified dates are the same, check IDs and delete records that have matching IDs
 		length := gjson.GetBytes(recordsJSON, "#").Int()
+		logging.Log.WithFields(logrus.Fields{"previous_record_ids": lastPosition.PreviousRecordIDs}).Debug("last modified date is the same, checking IDs")
 		// iterator for tracking index after deletes in json occur
 		correctedIterator := 0
 		for i := int64(0); i < length; i++ {

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -25,7 +25,7 @@ import (
 type Position struct {
 	LastModifiedDate  *time.Time
 	NextURL           string
-	PreviousRecordIDs []string
+	PreviousRecordIDs map[string]*time.Time
 }
 
 type LightningPoller struct {
@@ -45,11 +45,12 @@ type LightningPoller struct {
 }
 
 type RunConfig struct {
-	Queries                  []QueryWithCallback `validate:"required"`
-	StartupPositionOverrides map[string]time.Time
-	Ticker                   *time.Ticker
-	PersistenceEnabled       bool   `json:"persistence_enabled"`
-	PersistencePath          string `json:"persistence_path"`
+	Queries                            []QueryWithCallback `validate:"required"`
+	StartupPositionOverrides           map[string]time.Time
+	Ticker                             *time.Ticker
+	PersistenceEnabled                 bool          `json:"persistence_enabled"`
+	PersistencePath                    string        `json:"persistence_path"`
+	LastModifiedDateCorrectionDuration time.Duration `json:"last_modified_date_correction_duration"`
 }
 
 type QueryWithCallback struct {
@@ -238,8 +239,7 @@ func (p *LightningPoller) runQuery(queryWithCallback QueryWithCallback) error {
 // fast, then iterates over all results and compares with the saved IDs
 func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryWithCallback QueryWithCallback) (newRecordsJSON []byte, err error) {
 	newRecordsJSON = recordsJSON
-	resultLastModifiedDateString := getFinalLastModifiedDateStringFromJSON(recordsJSON)
-	resultLastModifiedDate, err := getTimestampFromResultLastModifiedDate(resultLastModifiedDateString)
+	resultLastModifiedDate, err := getFinalLastModifiedDateFromJSON(recordsJSON)
 	if err != nil {
 		errorutils.LogOnErr(nil, "error parsing LastModifiedDate", err)
 		return
@@ -253,16 +253,30 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 		correctedIterator := 0
 		for i := int64(0); i < length; i++ {
 			recordID := gjson.GetBytes(recordsJSON, fmt.Sprintf("%d.Id", i)).String()
-			if stringInSlice(recordID, lastPosition.PreviousRecordIDs) {
-				newRecordsJSON, err = sjson.DeleteBytes(newRecordsJSON, fmt.Sprintf("%d", correctedIterator))
-				if err != nil {
-					errorutils.LogOnErr(nil, "error removing record from json", err)
+			// check if the record ID is in the map of previously queried IDs.
+			// this prevents requeried record from being sent to the callback
+			// function every time after the poller has caught up.
+			if recordsPreviousLastModifiedDate, ok := lastPosition.PreviousRecordIDs[recordID]; ok {
+				// check if the last modified date is the same as before, then
+				// remove the record from the json if it is. if the
+				// LastModifiedDate does not match, then the record must have
+				// been updated again, so reprocess it.
+				currentRecordTimestamp, recordTimestampErr := getRecordsLastModifiedDate(correctedIterator, recordsJSON)
+				if recordTimestampErr != nil {
+					err = recordTimestampErr
 					return
 				}
-				// decrement corrected iterator when a record is removed
-				correctedIterator--
+				if recordsPreviousLastModifiedDate.Equal(currentRecordTimestamp) {
+					newRecordsJSON, err = sjson.DeleteBytes(newRecordsJSON, fmt.Sprintf("%d", correctedIterator))
+					if err != nil {
+						errorutils.LogOnErr(nil, "error removing record from json", err)
+						return
+					}
+					// decrement corrected iterator when a record is removed
+					correctedIterator--
+				}
 			}
-			// increment the correct iterator each time
+			// increment the corrected iterator each time
 			correctedIterator++
 		}
 		newRecordsLength := gjson.GetBytes(newRecordsJSON, "#").Int()
@@ -284,7 +298,7 @@ func (p *LightningPoller) handleSalesforceResponse(response pkg.SoqlResponse, re
 }
 
 func (p *LightningPoller) updatePosition(key string, response pkg.SoqlResponse, recordsJSON []byte) error {
-	newPosition, err := getPositionFromResult(response, recordsJSON)
+	newPosition, err := getPositionFromResult(response, recordsJSON, *p.positions[key])
 	if err != nil {
 		return err
 	}
@@ -300,39 +314,55 @@ func (p *LightningPoller) updatePosition(key string, response pkg.SoqlResponse, 
 	return nil
 }
 
-func getPositionFromResult(response pkg.SoqlResponse, recordsJSON []byte) (position Position, err error) {
+func getPositionFromResult(response pkg.SoqlResponse, recordsJSON []byte, previousPosition Position) (position Position, err error) {
 	// save last modified timestamp from last record in response
-	lastModifiedDate := getFinalLastModifiedDateStringFromJSON(recordsJSON)
-	if lastModifiedDate == "" {
-		logging.Log.WithFields(logrus.Fields{"json": string(recordsJSON)}).Debug("could not retrieve final last modified date from records json")
-		err = errors.New("could not retrieve final last modified date from records")
-		return
-	}
-	timestamp, timestampErr := getTimestampFromResultLastModifiedDate(lastModifiedDate)
+	timestamp, timestampErr := getFinalLastModifiedDateFromJSON(recordsJSON)
 	if timestampErr != nil {
 		err = timestampErr
 		return
 	}
 	position.LastModifiedDate = &timestamp
+
 	// save all of the record IDs of the response
-	lastQueriedIDs := []string{}
+	lastQueriedIDs := map[string]*time.Time{}
+
+	// if the last modified date is the same as the previous poll, then we will
+	// append the new IDs to the previous IDs. this prevents an infinite loop
+	// that occurs if the response from salesforce changes as a result of
+	// eventual consistency
+	if previousPosition.LastModifiedDate != nil && previousPosition.LastModifiedDate.Equal(timestamp) {
+		lastQueriedIDs = previousPosition.PreviousRecordIDs
+	}
+
 	gjsonIDresult := gjson.GetBytes(recordsJSON, "#.Id").Array()
-	for _, result := range gjsonIDresult {
-		lastQueriedIDs = append(lastQueriedIDs, result.String())
+	for i, result := range gjsonIDresult {
+		id := result.String()
+		recordTimestamp, recordTimestampErr := getRecordsLastModifiedDate(i, recordsJSON)
+		if recordTimestampErr != nil {
+			err = recordTimestampErr
+			return
+		}
+		lastQueriedIDs[id] = &recordTimestamp
 	}
 	position.PreviousRecordIDs = lastQueriedIDs
-	// save the next url
 	position.NextURL = response.NextRecordsUrl
 	return
 }
 
-func getFinalLastModifiedDateStringFromJSON(recordsJSON []byte) string {
+func getRecordsLastModifiedDate(recordPosition int, recordsJSON []byte) (lastModifiedDate time.Time, err error) {
+	path := fmt.Sprintf("%d.LastModifiedDate", recordPosition)
+	lastModifiedDateString := gjson.GetBytes(recordsJSON, path).String()
+	if lastModifiedDateString == "" {
+		logging.Log.WithFields(logrus.Fields{"json": string(recordsJSON)}).Debug("could not retrieve final last modified date from records json")
+		return lastModifiedDate, errors.New("could not retrieve final last modified date from records")
+	}
+	return getTimestampFromResultLastModifiedDate(lastModifiedDateString)
+}
+
+func getFinalLastModifiedDateFromJSON(recordsJSON []byte) (time.Time, error) {
 	numRecords := gjson.GetBytes(recordsJSON, "#").Int()
 	finalArrayIndex := numRecords - 1
-	path := fmt.Sprintf("%d.LastModifiedDate", finalArrayIndex)
-	finalLastModifiedDateResult := gjson.GetBytes(recordsJSON, path)
-	finalLastModifiedDateString := finalLastModifiedDateResult.String()
-	return finalLastModifiedDateString
+	return getRecordsLastModifiedDate(int(finalArrayIndex), recordsJSON)
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -360,6 +390,7 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	viper.AutomaticEnv() // read in environment variables that match
 	viper.SetDefault("grant_type", "password")
 	viper.SetDefault("poll_interval", "10s")
+	viper.SetDefault("last_modified_date_correction_duration", "5m")
 	viper.SetDefault("persistence_enabled", false)
 	viper.SetDefault("persistence_path", ".")
 	viper.SetDefault("api_version", "54.0")
@@ -370,11 +401,12 @@ func initConfig(queries []QueryWithCallback) (*RunConfig, error) {
 	}
 	logging.Log.WithFields(logrus.Fields{"startupPositionOverrides": startupPositionOverrides}).Debug("startup position overrides")
 	config := &RunConfig{
-		Queries:                  queries,
-		Ticker:                   time.NewTicker(viper.GetDuration("poll_interval")),
-		PersistenceEnabled:       viper.GetBool("persistence_enabled"),
-		PersistencePath:          viper.GetString("persistence_path"),
-		StartupPositionOverrides: startupPositionOverrides,
+		Queries:                            queries,
+		Ticker:                             time.NewTicker(viper.GetDuration("poll_interval")),
+		PersistenceEnabled:                 viper.GetBool("persistence_enabled"),
+		PersistencePath:                    viper.GetString("persistence_path"),
+		StartupPositionOverrides:           startupPositionOverrides,
+		LastModifiedDateCorrectionDuration: viper.GetDuration("last_modified_date_correction_duration"),
 	}
 	theValidator := validator.New()
 	err = theValidator.Struct(config)
@@ -437,14 +469,23 @@ func (p *LightningPoller) getPollQuery(queryWithCallback QueryWithCallback) (str
 	if strings.Contains(strings.ToLower(builder.String()), operator) {
 		operator = "and"
 	}
-	// use of rfc3339 is important here. SOQL uses + to indicate a space, so it parses out timestamp with + in them as a space, which is an invalid timestamp
-	// and then it gets mad that the datetime isn't valid because it made it invalid by replacing the + (for the timezone) with a space.
-	// if the time is not zero, use time - 2 seconds to make sure we never catch mid second updates
-	//if position.LastModifiedDate.UTC() != zeroTime.UTC() {
-	//	correctedTime := position.LastModifiedDate.Add(-2 * time.Second)
-	//	position.LastModifiedDate = &correctedTime
-	//}
-	dateTimeString := getRfcFormattedUtcTimestampString(*currentPosition.LastModifiedDate)
+
+	// copy the value of the pointer, so that we don't override
+	lastModifiedDate := *currentPosition.LastModifiedDate
+	// if we have caught all the way up, then we remove 5 minutes from the last
+	// modified date to ensure that we don't miss any records that were were
+	// missed as a result of eventual consistency or mid second updates
+	now := time.Now()
+	correctedTime := now.Add(-p.config.LastModifiedDateCorrectionDuration)
+	if lastModifiedDate.After(correctedTime) {
+		lastModifiedDate = correctedTime
+	}
+
+	// use of rfc3339 is important here. SOQL uses + to indicate a space, so it
+	// parses out timestamp with + in them as a space, which is an invalid
+	// timestamp and then it gets mad that the datetime isn't valid because it
+	// made it invalid by replacing the + (for the timezone) with a space.
+	dateTimeString := getRfcFormattedUtcTimestampString(lastModifiedDate)
 	builder.WriteString(fmt.Sprintf(" %s LastModifiedDate >= %s order by LastModifiedDate, Id", operator, dateTimeString))
 	return builder.String(), nil
 }
@@ -572,13 +613,4 @@ func (p *LightningPoller) doQuery(queryWithCallback QueryWithCallback) (bool, er
 
 func getTimestampFromResultLastModifiedDate(lastModifiedDate string) (timestamp time.Time, err error) {
 	return time.Parse("2006-01-02T15:04:05.000+0000", lastModifiedDate)
-}
-
-func stringInSlice(str string, slice []string) bool {
-	for _, v := range slice {
-		if v == str {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -267,6 +267,7 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 					return
 				}
 				if recordsPreviousLastModifiedDate.Equal(currentRecordTimestamp) {
+					logging.Log.WithFields(logrus.Fields{"record_id": recordID, "timestamp": currentRecordTimestamp}).Debug("removing record from json")
 					newRecordsJSON, err = sjson.DeleteBytes(newRecordsJSON, fmt.Sprintf("%d", correctedIterator))
 					if err != nil {
 						errorutils.LogOnErr(nil, "error removing record from json", err)
@@ -280,7 +281,11 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 			correctedIterator++
 		}
 		newRecordsLength := gjson.GetBytes(newRecordsJSON, "#").Int()
-		logging.Log.WithFields(logrus.Fields{"queried_records_total": length, "new_records_total": newRecordsLength}).Debug("removed already queried records")
+		logging.Log.WithFields(logrus.Fields{
+			"queried_records_total": length,
+			"new_records_total":     newRecordsLength,
+			"persistence_key":       queryWithCallback.PersistenceKey,
+		}).Debug("removed already queried records")
 		return
 	}
 	return

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -335,6 +335,7 @@ func getPositionFromResult(response pkg.SoqlResponse, recordsJSON []byte, previo
 	// append the new IDs to the previous IDs. this prevents an infinite loop
 	// that occurs if the response from salesforce changes as a result of
 	// eventual consistency
+	logging.Log.WithFields(logrus.Fields{"previous_last_modified_date": &previousPosition.LastModifiedDate, "new_position": timestamp}).Debug("comparing last modified dates")
 	if previousPosition.LastModifiedDate != nil && previousPosition.LastModifiedDate.Equal(timestamp) {
 		logging.Log.WithFields(logrus.Fields{"previous_record_ids": previousPosition.PreviousRecordIDs}).Debug("last modified date is the same as previous poll, appending IDs")
 		lastQueriedIDs = previousPosition.PreviousRecordIDs

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -263,7 +263,7 @@ func (p *LightningPoller) removeAlreadyQueriedRecords(recordsJSON []byte, queryW
 				// remove the record from the json if it is. if the
 				// LastModifiedDate does not match, then the record must have
 				// been updated again, so reprocess it.
-				currentRecordTimestamp, recordTimestampErr := getRecordsLastModifiedDate(correctedIterator, recordsJSON)
+				currentRecordTimestamp, recordTimestampErr := getRecordsLastModifiedDate(correctedIterator, newRecordsJSON)
 				if recordTimestampErr != nil {
 					err = recordTimestampErr
 					return

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -336,6 +336,7 @@ func getPositionFromResult(response pkg.SoqlResponse, recordsJSON []byte, previo
 	// that occurs if the response from salesforce changes as a result of
 	// eventual consistency
 	if previousPosition.LastModifiedDate != nil && previousPosition.LastModifiedDate.Equal(timestamp) {
+		logging.Log.WithFields(logrus.Fields{"previous_record_ids": previousPosition.PreviousRecordIDs}).Debug("last modified date is the same as previous poll, appending IDs")
 		lastQueriedIDs = previousPosition.PreviousRecordIDs
 	}
 


### PR DESCRIPTION
this is really a bug fix, but it adds a new configuration option, so
marking this as a feat instead.

changes:
- changed the PreviousRecordIDs to be a map that tracks the
  lastModifiedDate of a record.
- append to the PreviousRecordIDs map when the lastModifiedDate hasn't
  changed.
- add a configuration for requerying the last "x" amount of time when
  the poller has caught up to the current time.

this fixes a few problems:
- sometimes a response from salesforce will change upon subsequent
  queries by the same lastModifiedDate. this would cause an infinite
  querying loop to occur, as the initial query by the lastModifiedDate
  would save a set of IDs, then a new response from salesforce would
  return with the already saved IDs and some new IDs, old IDs would be
  removed from the returned records, which would cause the
  PreviousRecordIDs to flip back and forth between the old and new
  record IDs.
- the problem mentioned above suggests that the lastModifiedDate column
  isn't always updated in order. so to prevent the possibility of
  skipping records, the last_modified_date_correction_duration causes
  the poller to always repoll the previous "x" amount of time.
- if a record were to change multiple times in a row, the previous
  "PreviousRecordIDs" slice would falsely identify that a record was
  already handled. the use of tracking the lastModifiedDate in a map
  ensures that we rehandle records if their lastModifiedDate changes.