### PR TITLE
fix: handle invalid query locator error

### DIFF
--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -536,7 +536,7 @@ func (p *LightningPoller) doQuery(queryWithCallback QueryWithCallback) (bool, er
 	// attempt to query with the NextRecordsUrl first
 	nextRecordsURL := p.getNextRecordsURL(queryWithCallback)
 	if nextRecordsURL != "" {
-		logging.Log.WithFields(logrus.Fields{"persistence_key": queryWithCallback.PersistenceKey}).Info("using next records url")
+		logging.Log.WithFields(logrus.Fields{"persistence_key": queryWithCallback.PersistenceKey}).Debug("using next records url")
 		nextURLResponse, err := p.SfUtils.GetNextRecords(nextRecordsURL)
 		if err != nil {
 			// check if the NextRecordsUrl was not valid, return and

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -589,6 +589,7 @@ func (p *LightningPoller) doQuery(queryWithCallback QueryWithCallback) (bool, er
 		return false, err
 	}
 
+	logging.Log.WithFields(logrus.Fields{"persistence_key": queryWithCallback.PersistenceKey, "record_count": len(queryResponse.Records)}).Debug("got query response")
 	if len(queryResponse.Records) > 0 {
 		recordsJSON, err := json.Marshal(queryResponse.Records)
 		if err != nil {

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -589,7 +589,11 @@ func (p *LightningPoller) doQuery(queryWithCallback QueryWithCallback) (bool, er
 		return false, err
 	}
 
-	logging.Log.WithFields(logrus.Fields{"persistence_key": queryWithCallback.PersistenceKey, "record_count": len(queryResponse.Records)}).Debug("got query response")
+	logging.Log.WithFields(logrus.Fields{
+		"persistence_key": queryWithCallback.PersistenceKey,
+		"record_count":    len(queryResponse.Records),
+		"done":            queryResponse.Done,
+	}).Debug("got query response")
 	if len(queryResponse.Records) > 0 {
 		recordsJSON, err := json.Marshal(queryResponse.Records)
 		if err != nil {

--- a/pkg/lightning_poller.go
+++ b/pkg/lightning_poller.go
@@ -543,7 +543,9 @@ func (p *LightningPoller) doQuery(queryWithCallback QueryWithCallback) (bool, er
 			// log if it was some other error
 			// TODO could check the error better than this
 			if strings.Contains(err.Error(), "INVALID_QUERY_LOCATOR") {
-				logging.Log.WithFields(logrus.Fields{"persistence_key": queryWithCallback.PersistenceKey}).WithError(err).Error("invalid query locator")
+				logging.Log.WithFields(logrus.Fields{
+					"persistence_key": queryWithCallback.PersistenceKey,
+				}).WithError(err).Debug("invalid query locator, resetting next records url")
 				// if the query authenticator is invalid, then reset the next records url
 				p.saveNextRecordsURL("", queryWithCallback)
 				return true, nil


### PR DESCRIPTION
adds some debug logging to help trouble shoot errors in the future. 

the bug here is that we were checking for the invalid query locator error, but then not handling it, so we ended up returning that no records were returned from salesforce. 